### PR TITLE
Reverted to older build process (for runpath/rpath reasons)

### DIFF
--- a/openmpi_build.sh
+++ b/openmpi_build.sh
@@ -308,8 +308,10 @@ check_exit $? "Autogen.sh process"
 # Get the platform file from the plfs source directory, substituting the right
 # paths for the regression environment.
 echo "Generating platform file for openmpi compilation"
-catline="cat ${platform_file} > ./platform_file"
-eval $catline
+#catline="cat ${platform_file} > ./platform_file"
+sedline="sed 's|REPLACE_PLFS_LDFLAGS|${AD_PLFS_LDFLAGS}|g;s|REPLACE_PLFS_CFLAGS|${AD_PLFS_CFLAGS}|g' \
+    ${platform_file} > ./platform_file"
+eval $sedline
 check_exit $? "Generating platform file for openmpi"
 
 # Run configure

--- a/openmpi_platform_file.sample
+++ b/openmpi_platform_file.sample
@@ -2,6 +2,10 @@
 # otherwise parallel programs seem to have trouble with files.
 #
 with_io_romio_flags=--with-file-system=ufs+nfs+plfs
+LDFLAGS="REPLACE_PLFS_LDFLAGS"
+CFLAGS="REPLACE_PLFS_CFLAGS"
+CXXFLAGS="REPLACE_PLFS_CFLAGS"
+CCASFLAGS="REPLACE_PLFS_CFLAGS"
 
 # The following are needed to make sure all types of libraries are created.
 enable_shared=yes

--- a/tests/utils/rs_plfs_buildflags_get.py
+++ b/tests/utils/rs_plfs_buildflags_get.py
@@ -81,9 +81,8 @@ def get_rs_plfs_buildflags(reg_dir):
     rs_plfs_lib_dir = (str(reg_dir) + "/inst/plfs/lib")
     rs_plfs_inc_dir = (str(reg_dir) + "/inst/plfs/include")
     
-    rs_plfs_ldflags = ("-L" + str(rs_plfs_lib_dir) + " -Wl,-rpath="
-        + str(rs_plfs_lib_dir) + " -Wl,--whole-archive -lplfs -lpthread"
-        + " -Wl,--no-whole-archive")
+    rs_plfs_ldflags = ("-L" + str(rs_plfs_lib_dir) + " -Wl,-rpath -Wl,"
+        + str(rs_plfs_lib_dir) + " -Wl,--enable-new-dtags -lplfs -lpthread")
     rs_plfs_cflags = ("-I" + str(rs_plfs_inc_dir) + " -DHAS_PLFS")
     return [rs_plfs_cflags, rs_plfs_ldflags]
 


### PR DESCRIPTION
Reverting to the older build style so that OpenMPI is built in a way that users would expect in the majority of cases.  https://github.com/plfs/plfs-core/issues/320
