### PR TITLE
Modify all tests' reg_test.py so that they can run from command line

### DIFF
--- a/tests/adio_nto1_overwrite/reg_test.py
+++ b/tests/adio_nto1_overwrite/reg_test.py
@@ -167,6 +167,12 @@ def main(argv=None):
     return [0]
 
 if __name__ == "__main__":
+    # If reg_test.py is being called directly, make sure the regression suite's
+    # PLFS and MPI are in the appropriate environment variables. This should
+    # work because test_common was already loaded.
+    import rs_env_init
+    rs_env_init.add_plfs_paths(tc.basedir)
+
     result = main()
     if result[-1] > 0:
         sys.exit(0)

--- a/tests/adio_nto1_strided/reg_test.py
+++ b/tests/adio_nto1_strided/reg_test.py
@@ -115,6 +115,12 @@ def main(argv=None):
     return [0]
 
 if __name__ == "__main__":
+    # If reg_test.py is being called directly, make sure the regression suite's
+    # PLFS and MPI are in the appropriate environment variables. This should
+    # work because test_common was already loaded.
+    import rs_env_init
+    rs_env_init.add_plfs_paths(tc.basedir)
+
     result = main()
     if result[-1] > 0:
         sys.exit(0)

--- a/tests/adio_nton/reg_test.py
+++ b/tests/adio_nton/reg_test.py
@@ -115,6 +115,12 @@ def main(argv=None):
     return [last_id]
 
 if __name__ == "__main__":
+    # If reg_test.py is being called directly, make sure the regression suite's
+    # PLFS and MPI are in the appropriate environment variables. This should
+    # work because test_common was already loaded.
+    import rs_env_init
+    rs_env_init.add_plfs_paths(tc.basedir)
+
     result = main()
     if result[-1] > 0:
         sys.exit(0)

--- a/tests/adio_nton_overwrite/reg_test.py
+++ b/tests/adio_nton_overwrite/reg_test.py
@@ -166,6 +166,12 @@ def main(argv=None):
     return [0]
 
 if __name__ == "__main__":
+    # If reg_test.py is being called directly, make sure the regression suite's
+    # PLFS and MPI are in the appropriate environment variables. This should
+    # work because test_common was already loaded.
+    import rs_env_init
+    rs_env_init.add_plfs_paths(tc.basedir)
+
     result = main()
     if result[-1] > 0:
         sys.exit(0)

--- a/tests/adio_optimization/reg_test.py
+++ b/tests/adio_optimization/reg_test.py
@@ -115,6 +115,12 @@ def main(argv=None):
     return [0]
 
 if __name__ == "__main__":
+    # If reg_test.py is being called directly, make sure the regression suite's
+    # PLFS and MPI are in the appropriate environment variables. This should
+    # work because test_common was already loaded.
+    import rs_env_init
+    rs_env_init.add_plfs_paths(tc.basedir)
+
     result = main()
     if result[-1] > 0:
         sys.exit(0)

--- a/tests/adio_write_read/reg_test.py
+++ b/tests/adio_write_read/reg_test.py
@@ -113,6 +113,12 @@ def main(argv=None):
     return [last_id]
 
 if __name__ == "__main__":
+    # If reg_test.py is being called directly, make sure the regression suite's
+    # PLFS and MPI are in the appropriate environment variables. This should
+    # work because test_common was already loaded.
+    import rs_env_init
+    rs_env_init.add_plfs_paths(tc.basedir)
+
     result = main()
     if result[-1] > 0:
         sys.exit(0)

--- a/tests/chown/reg_test.py
+++ b/tests/chown/reg_test.py
@@ -166,6 +166,12 @@ def main(argv=None):
 #            return [ 0 ]
 
 if __name__ == "__main__":
+    # If reg_test.py is being called directly, make sure the regression suite's
+    # PLFS and MPI are in the appropriate environment variables. This should
+    # work because test_common was already loaded.
+    import rs_env_init
+    rs_env_init.add_plfs_paths(basedir)
+
     ret = main()
     # ret is a list, so don't return it to the shell. For now, just return a 0.
     sys.exit(0)

--- a/tests/cp_plfs_read/reg_test.py
+++ b/tests/cp_plfs_read/reg_test.py
@@ -189,6 +189,12 @@ def main(argv=None):
     return [0]
 
 if __name__ == "__main__":
+    # If reg_test.py is being called directly, make sure the regression suite's
+    # PLFS and MPI are in the appropriate environment variables. This should
+    # work because test_common was already loaded.
+    import rs_env_init
+    rs_env_init.add_plfs_paths(common.basedir)
+
     result = main()
     if result[-1] > 0:
         sys.exit(0)

--- a/tests/data-sieving/reg_test.py
+++ b/tests/data-sieving/reg_test.py
@@ -214,6 +214,12 @@ def main(argv=None):
     return [0]
 
 if __name__ == "__main__":
+    # If reg_test.py is being called directly, make sure the regression suite's
+    # PLFS and MPI are in the appropriate environment variables. This should
+    # work because test_common was already loaded.
+    import rs_env_init
+    rs_env_init.add_plfs_paths(common.basedir)
+
     result = main()
     if result[-1] > 0:
         sys.exit(0)

--- a/tests/dir_permissions/reg_test.py
+++ b/tests/dir_permissions/reg_test.py
@@ -166,6 +166,12 @@ def main(argv=None):
 #            return [ 0 ]
 
 if __name__ == "__main__":
+    # If reg_test.py is being called directly, make sure the regression suite's
+    # PLFS and MPI are in the appropriate environment variables. This should
+    # work because test_common was already loaded.
+    import rs_env_init
+    rs_env_init.add_plfs_paths(basedir)
+
     ret = main()
     # ret is a list, so don't return it to the shell. For now, just return a 0.
     sys.exit(0)

--- a/tests/dir_write/reg_test.py
+++ b/tests/dir_write/reg_test.py
@@ -167,6 +167,12 @@ def main(argv=None):
     return [0]
 
 if __name__ == "__main__":
+    # If reg_test.py is being called directly, make sure the regression suite's
+    # PLFS and MPI are in the appropriate environment variables. This should
+    # work because test_common was already loaded.
+    import rs_env_init
+    rs_env_init.add_plfs_paths(common.basedir)
+
     result = main()
     if result[-1] > 0:
         sys.exit(0)

--- a/tests/fd_consistency/reg_test.py
+++ b/tests/fd_consistency/reg_test.py
@@ -100,6 +100,12 @@ def main(argv=None):
     return [0]
 
 if __name__ == "__main__":
+    # If reg_test.py is being called directly, make sure the regression suite's
+    # PLFS and MPI are in the appropriate environment variables. This should
+    # work because test_common was already loaded.
+    import rs_env_init
+    rs_env_init.add_plfs_paths(tc.basedir)
+
     result = main()
     if result[-1] > 0:
         sys.exit(0)

--- a/tests/mkdir_ops/reg_test.py
+++ b/tests/mkdir_ops/reg_test.py
@@ -165,6 +165,12 @@ def main(argv=None):
 #            return [ 0 ]
 
 if __name__ == "__main__":
+    # If reg_test.py is being called directly, make sure the regression suite's
+    # PLFS and MPI are in the appropriate environment variables. This should
+    # work because test_common was already loaded.
+    import rs_env_init
+    rs_env_init.add_plfs_paths(basedir)
+
     ret = main()
     # ret is a list, so we don't want to just return it. At this point, we just
     # return a 0.

--- a/tests/non_adio_nto1_overwrite/reg_test.py
+++ b/tests/non_adio_nto1_overwrite/reg_test.py
@@ -167,6 +167,12 @@ def main(argv=None):
     return [0]
 
 if __name__ == "__main__":
+    # If reg_test.py is being called directly, make sure the regression suite's
+    # PLFS and MPI are in the appropriate environment variables. This should
+    # work because test_common was already loaded.
+    import rs_env_init
+    rs_env_init.add_plfs_paths(tc.basedir)
+
     result = main()
     if result[-1] > 0:
         sys.exit(0)

--- a/tests/non_adio_nton_overwrite/reg_test.py
+++ b/tests/non_adio_nton_overwrite/reg_test.py
@@ -170,6 +170,12 @@ def main(argv=None):
     return [0]
 
 if __name__ == "__main__":
+    # If reg_test.py is being called directly, make sure the regression suite's
+    # PLFS and MPI are in the appropriate environment variables. This should
+    # work because test_common was already loaded.
+    import rs_env_init
+    rs_env_init.add_plfs_paths(tc.basedir)
+
     result = main()
     if result[-1] > 0:
         sys.exit(0)

--- a/tests/noncontig_short/reg_test.py
+++ b/tests/noncontig_short/reg_test.py
@@ -181,6 +181,12 @@ def main(argv=None):
     return [0]
 
 if __name__ == "__main__":
+    # If reg_test.py is being called directly, make sure the regression suite's
+    # PLFS and MPI are in the appropriate environment variables. This should
+    # work because test_common was already loaded.
+    import rs_env_init
+    rs_env_init.add_plfs_paths(common.basedir)
+
     result = main()
     if result[-1] > 0:
         sys.exit(0)

--- a/tests/plfs_access/reg_test.py
+++ b/tests/plfs_access/reg_test.py
@@ -166,6 +166,12 @@ def main(argv=None):
 #            return [ 0 ]
 
 if __name__ == "__main__":
+    # If reg_test.py is being called directly, make sure the regression suite's
+    # PLFS and MPI are in the appropriate environment variables. This should
+    # work because test_common was already loaded.
+    import rs_env_init
+    rs_env_init.add_plfs_paths(basedir)
+
     ret = main()
     # ret is a list, so don't return it to the shell. For now, just return a 0.
     sys.exit(0)

--- a/tests/plfs_offset/reg_test.py
+++ b/tests/plfs_offset/reg_test.py
@@ -166,6 +166,12 @@ def main(argv=None):
 #            return [ 0 ]
 
 if __name__ == "__main__":
+    # If reg_test.py is being called directly, make sure the regression suite's
+    # PLFS and MPI are in the appropriate environment variables. This should
+    # work because test_common was already loaded.
+    import rs_env_init
+    rs_env_init.add_plfs_paths(basedir)
+
     ret = main()
     # ret is a list, so don't return it to the shell. For now, just return a 0.
     sys.exit(0)

--- a/tests/plfsrc/reg_test.py
+++ b/tests/plfsrc/reg_test.py
@@ -135,6 +135,12 @@ def main(argv=None):
         return [ 0 ]
 
 if __name__ == "__main__":
+    # If reg_test.py is being called directly, make sure the regression suite's
+    # PLFS and MPI are in the appropriate environment variables. This should
+    # work because test_common was already loaded.
+    import rs_env_init
+    rs_env_init.add_plfs_paths(basedir)
+
     ret = main()
     # ret is a list, so we don't want to just return it. At this point, we just
     # return a 0.

--- a/tests/posix_nto1_strided/reg_test.py
+++ b/tests/posix_nto1_strided/reg_test.py
@@ -151,6 +151,12 @@ def main(argv=None):
     return [0]
 
 if __name__ == "__main__":
+    # If reg_test.py is being called directly, make sure the regression suite's
+    # PLFS and MPI are in the appropriate environment variables. This should
+    # work because test_common was already loaded.
+    import rs_env_init
+    rs_env_init.add_plfs_paths(tc.basedir)
+
     result = main()
     if result[-1] > 0:
         sys.exit(0)

--- a/tests/posix_nton/reg_test.py
+++ b/tests/posix_nton/reg_test.py
@@ -151,6 +151,12 @@ def main(argv=None):
     return [0]
 
 if __name__ == "__main__":
+    # If reg_test.py is being called directly, make sure the regression suite's
+    # PLFS and MPI are in the appropriate environment variables. This should
+    # work because test_common was already loaded.
+    import rs_env_init
+    rs_env_init.add_plfs_paths(tc.basedir)
+
     result = main()
     if result[-1] > 0:
         sys.exit(0)

--- a/tests/readdir_ops/reg_test.py
+++ b/tests/readdir_ops/reg_test.py
@@ -166,6 +166,12 @@ def main(argv=None):
 #            return [ 0 ]
 
 if __name__ == "__main__":
+    # If reg_test.py is being called directly, make sure the regression suite's
+    # PLFS and MPI are in the appropriate environment variables. This should
+    # work because test_common was already loaded.
+    import rs_env_init
+    rs_env_init.add_plfs_paths(basedir)
+
     ret = main()
     # ret is a list, so don't return it to the shell. For now, just return a 0.
     sys.exit(0)

--- a/tests/rename/reg_test.py
+++ b/tests/rename/reg_test.py
@@ -237,6 +237,12 @@ def main(argv=None):
         return [ 0 ]
 
 if __name__ == "__main__":
+    # If reg_test.py is being called directly, make sure the regression suite's
+    # PLFS and MPI are in the appropriate environment variables. This should
+    # work because test_common was already loaded.
+    import rs_env_init
+    rs_env_init.add_plfs_paths(basedir)
+
     ret = main()
     # ret is a list, so we don't want to just return it. At this point, we just
     # return a 0.

--- a/tests/truncate/reg_test.py
+++ b/tests/truncate/reg_test.py
@@ -266,6 +266,12 @@ def main(argv=None):
         return [ 0 ]
 
 if __name__ == "__main__":
+    # If reg_test.py is being called directly, make sure the regression suite's
+    # PLFS and MPI are in the appropriate environment variables. This should
+    # work because test_common was already loaded.
+    import rs_env_init
+    rs_env_init.add_plfs_paths(basedir)
+
     ret = main()
     # ret is a list, so don't return it to the shell. Instead, at this point,
     # return a 0.

--- a/tests/truncate_open_file/reg_test.py
+++ b/tests/truncate_open_file/reg_test.py
@@ -198,6 +198,12 @@ def main(argv=None):
         return [ 0 ]
 
 if __name__ == "__main__":
+    # If reg_test.py is being called directly, make sure the regression suite's
+    # PLFS and MPI are in the appropriate environment variables. This should
+    # work because test_common was already loaded.
+    import rs_env_init
+    rs_env_init.add_plfs_paths(basedir)
+
     ret = main()
     # ret is a list, so we don't want to just return it. At this point, we just
     # return a 0.

--- a/tests/truncate_ops/reg_test.py
+++ b/tests/truncate_ops/reg_test.py
@@ -166,6 +166,12 @@ def main(argv=None):
 #            return [ 0 ]
 
 if __name__ == "__main__":
+    # If reg_test.py is being called directly, make sure the regression suite's
+    # PLFS and MPI are in the appropriate environment variables. This should
+    # work because test_common was already loaded.
+    import rs_env_init
+    rs_env_init.add_plfs_paths(basedir)
+
     ret = main()
     # ret is a list, so don't return it to the shell. For now, just return a 0.
     sys.exit(0)

--- a/tests/utils/rs_env_init.py
+++ b/tests/utils/rs_env_init.py
@@ -83,6 +83,5 @@ def add_plfs_paths(dir=None):
                 os.environ["LD_LIBRARY_PATH"])
     except KeyError:
         #LD_LIBRARYY_PATH is not in the dictionary of env variables yet.
-        os.environ["LD_LIBRARY_PATH"] = (mpi_inst_lib + ":" +
-            os.environ["LD_LIBRARY_PATH"])
+        os.environ["LD_LIBRARY_PATH"] = (mpi_inst_lib)
 

--- a/tests/write_read_error/reg_test.py
+++ b/tests/write_read_error/reg_test.py
@@ -177,6 +177,12 @@ def main(argv=None):
     return [0]
 
 if __name__ == "__main__":
+    # If reg_test.py is being called directly, make sure the regression suite's
+    # PLFS and MPI are in the appropriate environment variables. This should
+    # work because test_common was already loaded.
+    import rs_env_init
+    rs_env_init.add_plfs_paths(common.basedir)
+
     result = main()
     if result[-1] > 0:
         sys.exit(0)

--- a/tests/write_read_no_error/reg_test.py
+++ b/tests/write_read_no_error/reg_test.py
@@ -151,6 +151,12 @@ def main(argv=None):
     return [0]
 
 if __name__ == "__main__":
+    # If reg_test.py is being called directly, make sure the regression suite's
+    # PLFS and MPI are in the appropriate environment variables. This should
+    # work because test_common was already loaded.
+    import rs_env_init
+    rs_env_init.add_plfs_paths(tc.basedir)
+
     result = main()
     if result[-1] > 0:
         sys.exit(0)


### PR DESCRIPTION
The proper environment wasn't being used when running tests individually
from the command line (i.e. ./reg_test.py). Now they call the
appropriate helper scripts to make sure the regression suite's PLFS and
MPI are used.
